### PR TITLE
Small Fixes - SalesTax

### DIFF
--- a/lib/DDG/Goodie/SalesTax.pm
+++ b/lib/DDG/Goodie/SalesTax.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::SalesTax;
-#ABSTRACT: Returns the sales tax for any state (not including federal districts or territories) in the United States. 
+#ABSTRACT: Returns the sales tax for any state (not including territories) in the United States. 
 use DDG::Goodie;
 use Locale::SubCountry;
 use YAML::XS qw(Load);
@@ -8,9 +8,7 @@ triggers any => 'sales tax for', 'sales tax', 'sales tax in';
  
 zci answer_type => "sales_tax";
 zci is_cached   => 1;
- 
 
- 
 primary_example_queries 'Sales tax for pennsylvania', 'Sales tax pa';
 secondary_example_queries 'what is sales tax for mississippi';
 description 'Returns the sales tax of the specified state or territory in the United States';
@@ -20,21 +18,19 @@ category 'random';
 code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/SalesTax.pm";
 source "https://en.wikipedia.org/wiki/Sales_taxes_in_the_United_States";
 attribution github => ['https://github.com/javathunderman', 'Thomas Denizou'];
-         
+
 #Create US SubCountry object
 my $US = new Locale::SubCountry("US");
- 
+
 #Load states.yml
 #country-aliases file
 my $salestax = Load(scalar share('states.yml')->slurp);            
 
 handle remainder => sub {
-    #Define vars
-
-    my ($query,$state,$tax);
-        s/what is (the)?//g; # strip common words
+    my ($query,$state,$tax); #Define vars
+    s/what is (the)?//g; # strip common words
     $query = $_;
- 
+
     # Washington D.C is a district and is not supported by the SubCountry package.
     if($query =~ m/\b(washington\s(dc|d\.c))\b/i) {
         $state = "Washington D.C"

--- a/lib/DDG/Goodie/SalesTax.pm
+++ b/lib/DDG/Goodie/SalesTax.pm
@@ -28,7 +28,7 @@ my $salestax = Load(scalar share('states.yml')->slurp);
 
 handle remainder => sub {
     my ($query,$state,$tax); #Define vars
-    s/what is (the)?//g; # strip common words
+    s/^what is (the)?//g; # strip common words
     $query = $_;
 
     # Washington D.C is a district and is not supported by the SubCountry package.

--- a/t/SalesTax.t
+++ b/t/SalesTax.t
@@ -10,7 +10,6 @@ zci is_cached   => 1;
 
 ddg_goodie_test(
     [qw( DDG::Goodie::SalesTax )],
-            
     'Sales tax for pennsylvania' => test_zci(
         'Pennsylvania sales tax: 6%',
         structured_answer => {
@@ -38,10 +37,6 @@ ddg_goodie_test(
             
         }
     ),
-    
     'sales tax in japan' => undef
-    
-    
-   
    );
 done_testing;


### PR DESCRIPTION
@javathunderman Just removing some whitespace and updating the regexp `s/what is (the)?//g;` to `s/^what is (the)?//g;` `^` matches the start of a string.

Avoid triggering for queries:
* sales tax pennsylvania what is
* pa what is sales tax

:+1: 